### PR TITLE
Added open_todo.py

### DIFF
--- a/open_todo.py
+++ b/open_todo.py
@@ -1,0 +1,21 @@
+from datetime import date
+import os
+
+# A simple script to open a new markdown todo file every day. 
+
+year = date.today().year
+month = date.today().strftime('%b').lower()
+day = date.today().day
+
+filename  = os.path.join(str(year) + '_' + month, str(day) + '.md')
+try:
+    os.mkdir(os.path.abspath(str(year) + '_' + month))
+except:
+    pass
+file = open(filename, 'a')
+file.close()
+
+# replace this line with your way of opening markown files
+os.system('start typora ' + filename)
+
+# you could also just update a symbolic link and reference that link while opening your editor of choice


### PR DESCRIPTION
I added a simple script to orgnize daily todo files. It creates a new
markdown file every day and opens it in your favourite editor. It was
developed to work with Typora on Windows using python3. To get it to work
on other systems you would probably only need to updated the last line of
the script.